### PR TITLE
Adding the functionality of returning results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Find next some examples using Tacty:
 
 - [Using Tacty with the in memory resolver](https://github.com/cristiangsp/tacty/blob/master/samples/tacty_with_in_memory_resolver_usage.py)
 - [Using Tacty with a custom middleware](https://github.com/cristiangsp/tacty/blob/master/samples/tacty_with_custom_middleware.py)
+- [Using Tacty with a Handler that retuns a value](https://github.com/cristiangsp/tacty/blob/master/samples/tacty_with_handler_that_returns_a_value.py)

--- a/samples/tacty_with_custom_middleware.py
+++ b/samples/tacty_with_custom_middleware.py
@@ -19,8 +19,9 @@ class PrintNumberHandler(Handler):
 class PrintLoggerMiddleware(Middleware):
     def execute(self, command: object, next: Callable) -> any:
         print("Executing " + command.__class__.__name__)
-        next(command)
+        result = next(command)
         print(command.__class__.__name__ + " executed")
+        return result
 
 
 if __name__ == "__main__":

--- a/samples/tacty_with_handler_that_returns_a_value.py
+++ b/samples/tacty_with_handler_that_returns_a_value.py
@@ -1,0 +1,23 @@
+from tacty.command_bus import CommandBus
+from tacty.handler import Handler
+from tacty.middleware import CommandHandlerMiddleware
+from tacty.resolver import InMemoryResolver
+
+
+class AddTwoNumbersCommand:
+    def __init__(self, a: int, b: int):
+        self.a = a
+        self.b = b
+
+
+class AddTwoNumbersHandler(Handler):
+    def handle(self, command: AddTwoNumbersCommand):
+        return command.a + command.b
+
+
+if __name__ == "__main__":
+    resolver = InMemoryResolver()
+    resolver.add_handler(AddTwoNumbersCommand, AddTwoNumbersHandler())
+
+    command_bus = CommandBus([CommandHandlerMiddleware(resolver)])
+    print(command_bus.handle(AddTwoNumbersCommand(2, 3)))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tacty",  # Replace with your own username
-    version="1.0.2",
+    version="1.1.0",
     author="Cristian Gonzalez",
     author_email="cristian.gsp@gmail.com",
     description="An extensible command bus for Python 3",

--- a/tacty/command_bus.py
+++ b/tacty/command_bus.py
@@ -21,5 +21,5 @@ class CommandBus:
         
         return last_callable
 
-    def handle(self, command) -> None:
-        self.middleware_chain(command)
+    def handle(self, command) -> any:
+        return self.middleware_chain(command)

--- a/tacty/middleware/__init__.py
+++ b/tacty/middleware/__init__.py
@@ -16,4 +16,4 @@ class CommandHandlerMiddleware(Middleware):
 
     def execute(self, command: object, next: Callable) -> any:
         handler = self.resolver.resolve(type(command))
-        handler.handle(command)
+        return handler.handle(command)

--- a/tests/middleware/test_command_handler_middleware.py
+++ b/tests/middleware/test_command_handler_middleware.py
@@ -6,17 +6,31 @@ from tacty.middleware import CommandHandlerMiddleware
 
 
 class TestCommand:
-    pass
+    def __init__(self, value: int = 1000):
+        self.value = value
 
 
 class TestHandler(Handler):
     def handle(self, command: TestCommand) -> None:
-        pass
+        return command.value
 
 
 class TestCommandHandlerMiddleware(unittest.TestCase):
-    @patch('tacty.resolver.InMemoryResolver')
-    def test_assert_true(self, mock_resolver):
+    @patch('tacty.resolver.Resolver')
+    def test_commands_are_resolved_using_the_resolver(self, mock_resolver):
+        # Arrange
+        test_command = TestCommand()
+        mock_resolver.resolve = Mock()
+
+        # Act
+        middleware = CommandHandlerMiddleware(mock_resolver)
+        middleware.execute(test_command, lambda *args: None)
+
+        # Assert
+        mock_resolver.resolve.assert_called_with(type(test_command))
+
+    @patch('tacty.resolver.Resolver')
+    def test_handler_gets_executed(self, mock_resolver):
         # Arrange
         test_command = TestCommand()
         mock_test_handler = Mock()
@@ -29,5 +43,18 @@ class TestCommandHandlerMiddleware(unittest.TestCase):
         middleware.execute(test_command, lambda *args: None)
 
         # Assert
-        mock_resolver.resolve.assert_called_with(type(test_command))
         mock_test_handler.handle.assert_called_once_with(test_command)
+
+    @patch('tacty.resolver.Resolver')
+    def test_handler_returned_value_is_returned(self, mock_resolver):
+        # Arrange
+        test_command = TestCommand(2000)
+        mock_resolver.resolve = Mock()
+        mock_resolver.resolve.return_value = TestHandler()
+
+        # Act
+        middleware = CommandHandlerMiddleware(mock_resolver)
+        return_value = middleware.execute(test_command, lambda *args: None)
+
+        # Assert
+        self.assertEqual(return_value, test_command.value)

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -26,7 +26,7 @@ class LasttMiddleware(Middleware):
 
 
 class TestCommandBus(unittest.TestCase):
-    def test_adding_a_handler(self):
+    def test_middlewares_are_executed_in_order(self):
         # Arrange
         command_bus = CommandBus(
             [FirstMiddleware(), SecondMiddleware(), LasttMiddleware()]


### PR DESCRIPTION
This PR adds to the Command Bus the functionality of returning results.

Basically, handlers are allowed now to return values of `any` type and the `CommandHandlerMiddleware` returns them too. This way a command bus will be able to return values from a command execution which could be really useful for some use cases.

The changes include as well tweaks on the existing examples and adds a brand new one as example for returning values.

Finally, some test names have been tweaked to be more meaningful.